### PR TITLE
Fixing deletionRule decoding which was always returning 1 (nullify) fix #4

### DIFF
--- a/Sources/FromXML/MomRelationship+XMLObject.swift
+++ b/Sources/FromXML/MomRelationship+XMLObject.swift
@@ -23,7 +23,7 @@ extension MomRelationship: XMLObject {
         self.isOrdered = xml.element?.attribute(by: "ordered")?.text.toBool ?? false
         self.isTransient = xml.element?.attribute(by: "transient")?.text.toBool ?? false
 
-        if let text = xml.element?.attribute(by: "ordered")?.text, let rule = DeletionRule(rawValue: text) {
+        if let text = xml.element?.attribute(by: "deletionRule")?.text, let rule = DeletionRule(rawValue: text) {
             self.deletionRule = rule
         }
 


### PR DESCRIPTION
deletionRule element of relationships now decoded from 'ordered' deletionRule of 'ordered'
Closes #4 